### PR TITLE
Fixed error in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,7 @@ AI Services beschermt ons tegen vervelende boilerplate en zorgt ervoor dat we ge
 
 ```java
 AiServices.builder(Assistant.class)
-    .chatLanguageModel(OpenAiChatModel.builder()
+    .chatModel(OpenAiChatModel.builder()
        .apiKey("API_KEY")
        .modelName(OpenAiChatModelName.GPT_4)
        .build())


### PR DESCRIPTION
[In the ReadME]
AiServices.builder(Assistant.class)
.chatLanguageModel(OpenAiChatModel.builder()
.apiKey("API_KEY")
.modelName(OpenAiChatModelName.GPT_4)
.build())
.chatMemory(MessageWindowChatMemory.withMaxMessages(10))
.build();

chatLanguageModel Should be swapped to chatModel for no errors